### PR TITLE
fix: Carousel / fix extra space bug by adding width

### DIFF
--- a/client/src/components/UI/Carousel.module.css
+++ b/client/src/components/UI/Carousel.module.css
@@ -7,6 +7,7 @@
 
 .carouselList {
     display: flex;
+    width: 100%;
     overflow-x: scroll;
     -ms-overflow-style: none;
     scrollbar-width: 0;


### PR DESCRIPTION
# Issues
- Closes #8 

# Working Log
- add `width:100` to CarouselList(`ol`)